### PR TITLE
fix(registration): initialize diagnostics vars when optimize_poses=False

### DIFF
--- a/src/pyescan/tools/image_registration.py
+++ b/src/pyescan/tools/image_registration.py
@@ -408,6 +408,9 @@ def get_cleaned_poses(
             print(f"[optimize] worst edge: {worst} ({final_edge_errors[worst]:.3f})")
     else:
         optimized_poses = poses
+        outlier_edges = set()
+        untestable_edges = [e for e, s in edge_scores.items() if s is None]
+        final_edge_errors = {}
 
     # --- Centroid ---
     centroid = find_centroid_pose(optimized_poses)


### PR DESCRIPTION
Fixes `UnboundLocalError` in `get_cleaned_poses` when `return_diagnostics=True` and `optimize_poses=False` (the default).

## Problem

`outlier_edges`, `untestable_edges`, and `final_edge_errors` were only defined inside the `if optimize_poses:` branch, but referenced unconditionally in the diagnostics dict.

## Fix

Initialize sensible defaults in the `else` branch:
- `outlier_edges = set()` — no outlier removal performed
- `untestable_edges` — computed from edge_scores
- `final_edge_errors = {}` — no post-optimization residuals