### PR TITLE
Fix GitHub release repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,6 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" dist/* --verify-tag --generate-notes
+        run: >-
+          gh release create "${GITHUB_REF_NAME}" dist/*
+          --verify-tag --generate-notes --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Summary

The v0.0.2 workflow successfully published to PyPI, but its final GitHub release job failed because that job does not check out the repository. As a result, `gh release create` could not infer which repository to target.

Pass `GITHUB_REPOSITORY` explicitly through the `--repo` option. This keeps the release job checkout-free while allowing future tag releases to create their GitHub release and attach the validated distributions.

The v0.0.2 GitHub release was created manually from the exact workflow artifacts, and their SHA-256 hashes match the files published to PyPI.

## Validation

- Release workflow YAML parsed successfully
- Ruff formatting and lint checks passed
- Dependency audit passed
- Verified `gh release create --repo eye2gene/PyeScan` against v0.0.2